### PR TITLE
Update DSJwtAuth.js config path

### DIFF
--- a/lib/DSJwtAuth.js
+++ b/lib/DSJwtAuth.js
@@ -30,7 +30,7 @@ module.exports = DsJwtAuth;  // SET EXPORTS for the module.
 const moment = require('moment')
     , path = require('path')
     , docusign = require('docusign-esign')
-    , dsConfig = require('../ds_configuration.js').config
+    , dsConfig = require('../config).config
     , tokenReplaceMin = 10 // The accessToken must expire at least this number of
     , tokenReplaceMinGet = 30;
 


### PR DESCRIPTION
I think at some point the config was move to its own folder `config` and the `dsConfig` require path was never updated causing the application to error on start because cannot find the module. This fixes it