### PR TITLE
jwtConsole.js doesn't exit

### DIFF
--- a/jwt_console_project/jwtConsole.js
+++ b/jwt_console_project/jwtConsole.js
@@ -115,10 +115,16 @@ function prompt(prompt) {
 
 
 async function main(){
-  let accountInfo = await authenticate();
-  let args = await getArgs(accountInfo.apiAccountId, accountInfo.accessToken, accountInfo.basePath);
-  let envelopeId = await signingViaEmail.sendEnvelope(args);
-  console.log(envelopeId);
+  try {
+    let accountInfo = await authenticate();
+    let args = await getArgs(accountInfo.apiAccountId, accountInfo.accessToken, accountInfo.basePath);
+    let envelopeId = await signingViaEmail.sendEnvelope(args);
+    console.log(envelopeId);
+  } catch (error) {
+    console.error('An error occurred:', error);
+  } finally {
+    readline.close();
+  }
 }
 
 main();


### PR DESCRIPTION
Explicitly close the readline interface, the process will hang and not exit after the script finishes running, waiting for additional input.